### PR TITLE
Allow ASIds to be negative, for diff encoding

### DIFF
--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -402,10 +402,10 @@ CBOR encoding of the following extension values are partly supported:
    SubjectDirectoryAttributes = [+Attributes]
 ~~~~~~~~~~~
 
-* AS Resources (autonomousSysIds).  If rdi is not present, the extension value can be CBOR encoded. Each ASId is encoded as an uint. With the exception of the first ASId, the ASid is encoded as the difference to the previous ASid.
+* AS Resources (autonomousSysIds).  If rdi is not present, the extension value can be CBOR encoded. Each ASId is encoded as an int. With the exception of the first ASId, the ASid is encoded as the difference to the previous ASid.
 
 ~~~~~~~~~~~ CDDL
-   AsIdsOrRanges = uint / [uint, uint]
+   AsIdsOrRanges = int / [uint, uint]
    ASIdentifiers = [ + AsIdsOrRanges ] / null
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This from a suggestion part of Issue 102. I haven't seen any problem with allowing negative ASIds, to allow diff-encoding also of non-ordered lists of ASIds, but I propose this as a pull request, to allow the other authors to have one more look