### PR TITLE
Added "id-pe" to less used extensions

### DIFF
--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -301,7 +301,7 @@ This section details the encoding of the 'extensions' field. The 'extensions' fi
 
 The 'extnValue' OCTET STRING value field is encoded as the CBOR byte string 'extensionValue' except for the extensions specified below. For some extensions, only commonly used parts are supported by the CBOR encoding. If unsupported parts are used, the CBOR encoding cannot be used.
 
-A note on extension ID naming: in existing OID databases most IDs can be found in versions with and without an 'id-pe' or 'id-ce' prefix. We have excluded the prefix for the commonly used extensions defined in {{REF5280}} and included them in for extensions defined elsewhere.
+A note on extension ID naming: in existing OID databases most IDs can be found in versions with and without an 'id-pe' or 'id-ce' prefix. We have excluded the prefix for the commonly used extensions defined in {{REF5280}} and included them for extensions defined elsewhere.
 
 CBOR encoding of the following extension values is fully supported:
 

--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -301,7 +301,9 @@ This section details the encoding of the 'extensions' field. The 'extensions' fi
 
 The 'extnValue' OCTET STRING value field is encoded as the CBOR byte string 'extensionValue' except for the extensions specified below. For some extensions, only commonly used parts are supported by the CBOR encoding. If unsupported parts are used, the CBOR encoding cannot be used.
 
-CBOR encoding of the following extension values are fully supported:
+A note on extension ID naming: on the Internet most IDs can be found in versions with and without an 'id-pe' or 'id-ce' prefix. We have excluded the prefix for the commonly used extensions defined in {{REF5280}} and included them in for extensions defined elsewhere.
+
+CBOR encoding of the following extension values is fully supported:
 
 *  Subject Key Identifier (subjectKeyIdentifier). The extensionValue is encoded as follows:
 
@@ -418,7 +420,7 @@ CBOR encoding of the following extension values are partly supported:
    ]
 ~~~~~~~~~~~
 
-* Name Constraints (nameConstraints). If the name constraints only contains general names registered in {{GN}} the extension value can be CBOR encoded. Note that {{RFC5280}} requires that minimum MUST be zero, and maximum MUST be absent.
+* Name Constraints (nameConstraints). If the name constraints only contain general names registered in {{GN}} the extension value can be CBOR encoded. Note that {{RFC5280}} requires that minimum MUST be zero, and maximum MUST be absent.
 
 ~~~~~~~~~~~ CDDL
    GeneralSubtree = [ GeneralName ]

--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -301,7 +301,7 @@ This section details the encoding of the 'extensions' field. The 'extensions' fi
 
 The 'extnValue' OCTET STRING value field is encoded as the CBOR byte string 'extensionValue' except for the extensions specified below. For some extensions, only commonly used parts are supported by the CBOR encoding. If unsupported parts are used, the CBOR encoding cannot be used.
 
-A note on extension ID naming: on the Internet most IDs can be found in versions with and without an 'id-pe' or 'id-ce' prefix. We have excluded the prefix for the commonly used extensions defined in {{REF5280}} and included them in for extensions defined elsewhere.
+A note on extension ID naming: in existing OID databases most IDs can be found in versions with and without an 'id-pe' or 'id-ce' prefix. We have excluded the prefix for the commonly used extensions defined in {{REF5280}} and included them in for extensions defined elsewhere.
 
 CBOR encoding of the following extension values is fully supported:
 

--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -436,14 +436,14 @@ CBOR encoding of the following extension values are partly supported:
    SubjectDirectoryAttributes = [+Attributes]
 ~~~~~~~~~~~
 
-* AS Resources (autonomousSysIds).  If rdi is not present, the extension value can be CBOR encoded. Each ASId is encoded as an uint. With the exception of the first ASId, the ASid is encoded as the difference to the previous ASid.
+* AS Resources (id-pe-autonomousSysIds).  If rdi is not present, the extension value can be CBOR encoded. Each ASId is encoded as an uint. With the exception of the first ASId, the ASid is encoded as the difference to the previous ASid.
 
 ~~~~~~~~~~~ CDDL
    AsIdsOrRanges = uint / [uint, uint]
    ASIdentifiers = [ + AsIdsOrRanges ] / null
 ~~~~~~~~~~~
 
-* AS Resources v2 (autonomousSysIds-v2). Encoded exactly like autonomousSysIds.
+* AS Resources v2 (id-pe-autonomousSysIds-v2). Encoded exactly like autonomousSysIds.
 
 * IP Resources (id-pe-ipAddrBlocks).  If rdi and SAFI is not present, the extension value can be CBOR encoded. Each AddressPrefix is encoded as a CBOR bytes string (without the unused bits octet) followed by the number of unused bits encoded as a CBOR uint. Each AddressRange is encoded as an array of two CBOR byte strings. The unused bits for min and max are omitted, but the unused bits in max IPAddress is set to ones. With the exception of the first  Address, if the byte string has the same length as the previous Address, the Address is encoded as an uint with the the difference to the previous Address. It should be noted that using address differences for compactness prevents encoding an address range larger than 2^64 - 1 corresponding to the cbor integer max value.
 
@@ -996,7 +996,7 @@ IANA has created a new registry titled "C509 Extensions Registry" under the new 
 |       | extensionValue:  IPAddrBlocks                             |
 +-------+-----------------------------------------------------------+
 |    33 | Name:            AS Resources                             |
-|       | Identifiers:     autonomousSysIds                         |
+|       | Identifiers:     id-pe-autonomousSysIds                   |
 |       | OID:             1.3.6.1.5.5.7.1.8                        |
 |       | DER:             06 08 2B 06 01 05 05 07 01 08            |
 |       | Comments:                                                 |
@@ -1010,14 +1010,14 @@ IANA has created a new registry titled "C509 Extensions Registry" under the new 
 |       | extensionValue:  IPAddrBlocks                             |
 +-------+-----------------------------------------------------------+
 |    35 | Name:            AS Resources v2                          |
-|       | Identifiers:     autonomousSysIds-v2                      |
+|       | Identifiers:     id-pe-autonomousSysIds-v2                |
 |       | OID:             1.3.6.1.5.5.7.1.29                       |
 |       | DER:             06 08 2B 06 01 05 05 07 01 1D            |
 |       | Comments:                                                 |
 |       | extensionValue:  ASIdentifiers                            |
 +-------+-----------------------------------------------------------+
 |    36 | Name:            Biometric Information                    |
-|       | Identifiers:     biometricInfo                            |
+|       | Identifiers:     id-pe-biometricInfo                      |
 |       | OID:             1.3.6.1.5.5.7.1.2                        |
 |       | DER:             06 08 2B 06 01 05 05 07 01 02            |
 |       | Comments:                                                 |


### PR DESCRIPTION
A compromise suggestion. Almost all extensions in the C509 Extensions Registry appear on the internet both with a (id-ce or id-pe) prefix and without. This proposal is to:
- Keep the more commonly used ones, which are defined in rfc5280, without the prefix
- To consistently let the more uncommon ones match their definitions as given in respective rfc.