### PR TITLE
Location of signature algorithm in CSR

### DIFF
--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -597,11 +597,11 @@ C509CertificateRequest = [
 ; The elements of the following group are used in a CBOR Sequence:
 TBSCertificateRequest = (
    c509CertificateRequestType: int,
+   subjectSignatureAlgorithm: AlgorithmIdentifier,
    subject: Name,
    subjectPublicKeyAlgorithm: AlgorithmIdentifier,
    subjectPublicKey: any,
    extensionsRequest: Extensions,
-   subjectSignatureAlgorithm: AlgorithmIdentifier,
 )
 
 challengePassword: tstr / bstr


### PR DESCRIPTION
Missed this in #149. Fixes #167.