### PR TITLE
C509PrivateKey - Remove editors note

### DIFF
--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -889,8 +889,8 @@ IANA has created a new registry titled "C509 Private Key Types" under the new he
 +-------+-----------------------------------------------------------+
 | Value | Description                                               |
 +=======+===========================================================+
-|     0 | Byte string encoding based on Asymmetric Key Packages     |
-|       | as defined in RFC 5958                                    |
+|     0 | CBOR byte string encoding based on Asymmetric Key         |
+|       | Packages as defined in RFC 5958                           |
 +-------+-----------------------------------------------------------+
 ~~~~~~~~~~~
 {: #fig-rivkeys title="C509 Private Key Types"}

--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -893,7 +893,7 @@ IANA has created a new registry titled "C509 Private Key Types" under the new he
 |       | as defined in RFC 5958                                    |
 +-------+-----------------------------------------------------------+
 ~~~~~~~~~~~
-{: #fig-types title="C509 Certificate Types"}
+{: #fig-rivkeys title="C509 Private Key Types"}
 {: artwork-align="center"}
 
 ## C509 Attributes Registry {#atttype}

--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -614,7 +614,7 @@ C509PrivateKey = [
 ~~~~~~~~~~~
 {: sourcecode-name="c509.cddl"}
 
-The field 'C509PrivateKeyType' indicates the type of the C509 private key. Currently, the only defined type (C509PrivateKeyType = 0) is based on Asymmetric Key Packages {{RFC5958}}. When C509PrivateKeyType = 0, the subjectPrivateKey is the CBOR byte string encoding of the PrivateKey OCTET STRING value field defined in {{RFC5958}}.
+The field 'C509PrivateKeyType' indicates the type of the C509 private key. Different types of C509 Private Key Structures can be defined, see {{privkeys}}. Currently, the only defined type (C509PrivateKeyType = 0) is based on Asymmetric Key Packages {{RFC5958}}. When C509PrivateKeyType = 0, the subjectPrivateKey is the CBOR byte string encoding of the PrivateKey OCTET STRING value field defined in {{RFC5958}}.
 
 The C509PrivateKey item is served with the application/cose-c509-privkey media type, see {{c509-privkey}}, with corresponding CoAP Content-Format defined in {{content-format}}. A stored file format is defined in {{RFC9277}}, with "magic number" TBD12 composed of the reserved CBOR tag 55799 concatenated with the CBOR tag calculated from the CoAP Content-Format value.
 
@@ -879,6 +879,21 @@ IANA has created a new registry titled "C509 Certificate Request Types" under th
 +-------+-----------------------------------------------------------+
 ~~~~~~~~~~~
 {: #fig-csr-types title="C509 Certificate Request Types"}
+{: artwork-align="center"}
+
+## C509 Private Key Types {#privkeys}
+
+IANA has created a new registry titled "C509 Private Key Types" under the new heading "CBOR Encoded X.509 (C509) Parameters". The columns of the registry are Value, Description, and Reference, where Value is an integer, and the other columns are text strings. For values in the interval \[-24, 23\] the registration procedure is "IETF Review" and "Expert Review". For all other values the registration procedure is "Expert Review".  The initial contents of the registry are:
+
+~~~~~~~~~~~ aasvg
++-------+-----------------------------------------------------------+
+| Value | Description                                               |
++=======+===========================================================+
+|     0 | Byte string encoding based on Asymmetric Key Packages     |
+|       | as defined in RFC 5958                                    |
++-------+-----------------------------------------------------------+
+~~~~~~~~~~~
+{: #fig-types title="C509 Certificate Types"}
 {: artwork-align="center"}
 
 ## C509 Attributes Registry {#atttype}

--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -48,6 +48,7 @@ normative:
   RFC3986:
   RFC4108:
   RFC5280:
+  RFC5958:
   RFC6698:
   RFC6838:
   RFC6962:
@@ -606,11 +607,14 @@ Certificate management also makes use of data structures including private keys,
 
 ~~~~~~~~~~~ cddl
 C509PrivateKey = [
+   C509PrivateKeyType: int,
    subjectPrivateKeyAlgorithm: AlgorithmIdentifier,
    subjectPrivateKey: any,
 ]
 ~~~~~~~~~~~
 {: sourcecode-name="c509.cddl"}
+
+The field 'C509PrivateKeyType' indicates the type of the C509 private key. Currently, the only defined type (C509PrivateKeyType = 0) is based on Asymmetric Key Packages {{RFC5958}}. When C509PrivateKeyType = 0, the subjectPrivateKey is the CBOR byte string encoding of the PrivateKey OCTET STRING value field defined in {{RFC5958}}.
 
 The C509PrivateKey item is served with the application/cose-c509-privkey media type, see {{c509-privkey}}, with corresponding CoAP Content-Format defined in {{content-format}}. A stored file format is defined in {{RFC9277}}, with "magic number" TBD12 composed of the reserved CBOR tag 55799 concatenated with the CBOR tag calculated from the CoAP Content-Format value.
 
@@ -623,8 +627,6 @@ C509PEM = [
 {: sourcecode-name="c509.cddl"}
 
 The C509PEM item is served with the application/cose-c509-pem media type, see {{c509-pem}}, with corresponding CoAP Content-Format defined in {{content-format}}. A stored file format is defined in {{RFC9277}}, with "magic number" TBD13 composed of the reserved CBOR tag 55799 concatenated with the CBOR tag calculated from the CoAP Content-Format value.
-
-Editor's note: Include further details for encoding of subjectPrivateKey.
 
 ## Deterministic Encoding
 


### PR DESCRIPTION
C509PrivateKey - Remove editors note

Introduced a type field and refer to RFC 5958. Removed editor's note.