### PR TITLE
Fixed #292: Extension CRLDistributionPoints

### DIFF
--- a/draft-ietf-cose-cbor-encoded-cert.md
+++ b/draft-ietf-cose-cbor-encoded-cert.md
@@ -451,7 +451,7 @@ CBOR encoding of the following extension values are partly supported:
 
 ~~~~~~~~~~~ cddl
    DistributionPointName = [
-     fullName  [2* text] / text,
+     fullName  [ 2 * text ] / text,
      reasons   uint / null,
      cRLIssuer Name / null,
    ]


### PR DESCRIPTION
extend the definition to support cRLIssuer and reasons